### PR TITLE
Change path to fsPath

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
           return [];
         }
 
-        const file = model.uri.path;
+        const file = model.uri.fsPath;
         const hint: any = await vscode.commands.executeCommand(
           "typescript.tsserverRequest",
           "quickinfo",


### PR DESCRIPTION
**TL;DR:** Using path resulted in errors for tsserver in non-unix platforms due to the tsserver not finding the specified file.

To debug this issue (#1), I got logs from tsserver by following [these instructions](https://stackoverflow.com/a/39758878) (and the ones in the official [tsserver docs](https://github.com/microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29#logging)), opened vscode and then tried to use the extension on a TypeScript project.

> **Note**
> I would share the logs I got but unfortunately they contain sensitive information such as file paths and project names. 

The issue was that the path the extension was sending to tsserver was something like `/c:/Users/...` when, in Windows, they should look like `c:\\Users\...`.

[`fsPath`](https://code.visualstudio.com/api/references/vscode-api#Uri:~:text=The%20difference%20to%20the%20path%2Dproperty) handles drive letters and directory separators across different platforms.

---------------------

Fixes #1 
