### PR TITLE
Support virtual files such as untitled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+.vscode-test-web

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.2",
   "engines": {
     "vscode": "^1.67.0"
-  },  
+  },
   "icon": "icon.png",
   "categories": [
     "Other"
@@ -23,6 +23,7 @@
     "url": "https://github.com/orta/vscode-twoslash-queries"
   },
   "main": "./out/extension.js",
+  "browser": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "compile": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,13 +25,13 @@ export function activate(context: vscode.ExtensionContext) {
           return [];
         }
 
-        const file = model.uri.fsPath;
+        const { scheme, fsPath, authority, path } = model.uri;
         const hint: any = await vscode.commands.executeCommand(
           "typescript.tsserverRequest",
           "quickinfo",
           {
             _: "%%%",
-            file,
+            file: scheme === 'file' ? fsPath : `^/${scheme}/${authority || 'ts-nul-authority'}/${path.replace(/^\//, '')}`,
             line: inspectionPos.line + 1,
             offset: inspectionPos.character,
           }


### PR DESCRIPTION
Follow up of https://github.com/orta/vscode-twoslash-queries/pull/4

Make it work with any schemas (any file system providers) such as GitHub Repositories.

Reference of how TS constructs the path:

https://github.com/microsoft/vscode/blob/f3f9f7a10d877fd2177daec3e1f6054706c7e5bc/extensions/typescript-language-features/src/typescriptServiceClient.ts#L689 I just inlined the constants