### PR TITLE
Add inline query

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Useful for keyboard warriors or folks working on complex types and want to see h
 
 You write `// ^?` anywhere in a source file (with whitespace before, between and middle being whatever) all that matters is the alignment of the `^`.
 
+Alternatively, end a line with `//=>` to highlight the leftmost named type.
+
 You can see here it in use a few times:
 
 <img src="./vscode-twoslash.png" />

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,65 +1,13 @@
 import * as vscode from "vscode";
+import { getHintsFromQueries } from "./queries";
 
 export function activate(context: vscode.ExtensionContext) {
   const provider: vscode.InlayHintsProvider = {
     provideInlayHints: async (model, iRange, cancel) => {
       const offset = model.offsetAt(iRange.start);
       const text = model.getText(iRange);
-      const results: vscode.InlayHint[] = [];
 
-      const m = text.matchAll(/^\s*\/\/\s*\^\?/gm);
-      for (const match of m) {
-        if (match.index === undefined) {
-          return;
-        }
-
-        const end = match.index + match[0].length - 1;
-        // Add the start range for the inlay hint
-        const endPos = model.positionAt(end + offset);
-        const inspectionPos = new vscode.Position(
-          endPos.line - 1,
-          endPos.character
-        );
-
-        if (cancel.isCancellationRequested) {
-          return [];
-        }
-
-        const { scheme, fsPath, authority, path } = model.uri;
-        const hint: any = await vscode.commands.executeCommand(
-          "typescript.tsserverRequest",
-          "quickinfo",
-          {
-            _: "%%%",
-            file: scheme === 'file' ? fsPath : `^/${scheme}/${authority || 'ts-nul-authority'}/${path.replace(/^\//, '')}`,
-            line: inspectionPos.line + 1,
-            offset: inspectionPos.character,
-          }
-        );
-
-        if (!hint || !hint.body) {
-          continue;
-        }
-
-        // Make a one-liner
-        let text = hint.body.displayString
-          .replace(/\\n/g, " ")
-          .replace(/\/n/g, " ")
-          .replace(/  /g, " ")
-          .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
-        if (text.length > 120) {
-          text = text.slice(0, 119) + "...";
-        }
-
-        const inlay: vscode.InlayHint = {
-          kind: 0,
-          position: new vscode.Position(endPos.line, endPos.character + 1),
-          label: text,
-          paddingLeft: true,
-        };
-        results.push(inlay);
-      }
-      return results;
+      return await getHintsFromQueries({ text, offset, model, cancel });
     },
   };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -38,7 +38,7 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
   
   // Cut off hint if too long
-  // If vscode #174159 lands, can change to check that (https://github.com/microsoft/vscode/issues/174159)
+  // If microsoft/vscode#174159 lands, can change to check that
   const availableSpace = 120 - lineLength;
   if (text.length > availableSpace) {
     text = text.slice(0, availableSpace - 1) + "...";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,74 @@
+import * as vscode from "vscode";
+import type { QuickInfoResponse } from "typescript/lib/protocol";
+
+export type Model = vscode.TextDocument;
+
+/** Leverages the `tsserver` protocol to try to get the type info at the given `position`. */
+export async function quickInfoRequest(model: Model, position: vscode.Position) {
+  const { scheme, fsPath, authority, path } = model.uri;
+  return await vscode.commands.executeCommand(
+    "typescript.tsserverRequest",
+    "quickinfo",
+    {
+      _: "%%%",
+      file: scheme === 'file' ? fsPath : `^/${scheme}/${authority || 'ts-nul-authority'}/${path.replace(/^\//, '')}`,
+      line: position.line,
+      offset: position.character,
+    }
+  ) as any as QuickInfoResponse | undefined;
+}
+
+type InlayHintInfo = {
+  hint: QuickInfoResponse | undefined;
+  position: vscode.Position;
+  lineLength?: number;
+};
+
+/** Creates a `vscode.InlayHint` to display a `QuickInfo` response. */
+export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInfo): vscode.InlayHint | undefined {
+  if (!hint || !hint.body) {
+    return;
+  }
+  
+  // Make a one-liner
+  let text = hint.body.displayString
+    .replace(/\\n/g, " ")
+    .replace(/\/n/g, " ")
+    .replace(/  /g, " ")
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
+  
+  // Cut off hint if too long
+  // If vscode #174159 lands, can change to check that (https://github.com/microsoft/vscode/issues/174159)
+  const availableSpace = 120 - lineLength;
+  if (text.length > availableSpace) {
+    text = text.slice(0, availableSpace - 1) + "...";
+  }
+
+  return {
+    kind: 0,
+    position: position.translate(0, 1),
+    label: text,
+    paddingLeft: true,
+  };
+}
+
+const range = (num: number) => [...Array(num).keys()];
+
+type LineInfo = {
+  model: Model;
+  position: vscode.Position;
+  lineLength: number;
+};
+
+/** Gets the first `QuickInfo` response in a given line, if available. */
+export async function getLeftMostHintOfLine({ model, position, lineLength }: LineInfo) {
+  for (const i of range(lineLength)) {
+    const hint = await quickInfoRequest(model, position.translate(0, i));
+  
+    if (!hint || !hint.body) {
+      continue;
+    }
+
+    return hint;
+  }
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -14,7 +14,8 @@ type RegExpGroups<T extends string> = (
   }[]
 );
 
-const twoslashQueryRegex = /^\s*\/\/\s*\^\?/gm; // symbol: ^?
+
+const twoslashQueryRegex = /^\s*\/\/\.?\s*\^\?/gm; // symbol: ^?
 const inlineQueryRegex = /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
 type InlineQueryMatches = RegExpGroups<"start" | "end">;
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,0 +1,102 @@
+import * as vscode from "vscode";
+import {
+  type Model,
+  quickInfoRequest,
+  createInlayHint,
+  getLeftMostHintOfLine
+} from "./helpers";
+
+/** Strongly-typed RegExp groups (https://github.com/microsoft/TypeScript/issues/32098#issuecomment-1279645368) */
+type RegExpGroups<T extends string> = (
+  & IterableIterator<RegExpMatchArray>
+  & {
+    groups: { [name in T]: string } | { [key: string]: string };
+  }[]
+);
+
+const twoslashQueryRegex = /^\s*\/\/\s*\^\?/gm; // symbol: ^?
+const inlineQueryRegex = /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
+type InlineQueryMatches = RegExpGroups<"start" | "end">;
+
+type Query = {
+  text: string;
+  offset: number;
+  model: Model;
+  cancel: vscode.CancellationToken;
+};
+
+type InlayHintsPromise = Promise<vscode.InlayHint[]>;
+
+/** Checks for and returns regular two-slash query hints (symbol: ^?). */
+async function checkTwoslashQuery({ text, offset, model, cancel }: Query): InlayHintsPromise {
+  const results: vscode.InlayHint[] = [];
+  const m = text.matchAll(twoslashQueryRegex);
+
+  for (const match of m) {
+    if (match.index === undefined) {
+      break;
+    }
+
+    const end = match.index + match[0].length - 1;
+    // Add the start range for the inlay hint
+    const endPos = model.positionAt(end + offset);
+
+    if (cancel.isCancellationRequested) {
+      return [];
+    }
+
+    const hint = await quickInfoRequest(model, endPos.translate(-1));
+    const inlayHint = createInlayHint({ hint, position: endPos });
+    
+    if(inlayHint) {
+      results.push(inlayHint);
+    }
+  }
+
+  return results;
+}
+
+/** Checks for and returns inline query hints (symbol: =>). */
+async function checkInlineQuery({ text, offset, model, cancel }: Query): InlayHintsPromise {
+  const results: vscode.InlayHint[] = [];
+  const m = text.matchAll(inlineQueryRegex) as InlineQueryMatches;
+
+  for (const match of m) {
+    if (match.index === undefined) {
+      break;
+    }
+
+    if (cancel.isCancellationRequested) {
+      return [];
+    }
+
+    const [line] = match;
+    const { start, end: querySymbol } = match.groups;
+    const startIndex = line.indexOf(start);
+    const startPos = model.positionAt(startIndex + offset + match.index);
+    const endIndex = line.lastIndexOf(querySymbol) + 2;
+    const endPos = model.positionAt(endIndex + offset + match.index);
+
+    const hint = await getLeftMostHintOfLine({model, position: startPos, lineLength: endIndex - startIndex - 2});
+    const inlayHint = createInlayHint({ hint, position: endPos, lineLength: line.length });
+    
+    if(inlayHint) {
+      results.push(inlayHint);
+    }
+  }
+
+  return results;
+}
+
+/** Sequentially checks each type of query for hints to display. */
+export async function getHintsFromQueries(queryInfo: Query): InlayHintsPromise {
+  const queries = [checkTwoslashQuery, checkInlineQuery];
+  const results: vscode.InlayHint[] = [];
+
+  for (const query of queries) {
+    const queryResults = await query(queryInfo);
+    results.push(...queryResults);
+  }
+
+  return results;
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -16,6 +16,7 @@ type RegExpGroups<T extends string> = (
 
 
 const twoslashQueryRegex = /^\s*\/\/\.?\s*\^\?/gm; // symbol: ^?
+// https://regex101.com/r/6Jb8h2/1
 const inlineQueryRegex = /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
 type InlineQueryMatches = RegExpGroups<"start" | "end">;
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -77,7 +77,7 @@ async function checkInlineQuery({ text, offset, model, cancel }: Query): InlayHi
     const endIndex = line.lastIndexOf(querySymbol) + 2;
     const endPos = model.positionAt(endIndex + offset + match.index);
 
-    const hint = await getLeftMostHintOfLine({model, position: startPos, lineLength: endIndex - startIndex - 2});
+    const hint = await getLeftMostHintOfLine({ model, position: startPos, lineLength: endIndex - startIndex - 2 });
     const inlayHint = createInlayHint({ hint, position: endPos, lineLength: line.length });
     
     if(inlayHint) {


### PR DESCRIPTION
Resolves #8 

Adds an inline query. If a `=>`[^1] is present at the end of a line, displays the first inlay hint found, starting from the left of the line:

```ts
const x = { y: "z" };
x.y; //=> `const x: { y: string };`
```

I've refactored logic into `queries.ts` and `helpers.ts`.

[^1]: Maybe the `<?` query could display the right-most hint? A number after both could display the next hint in line.