### PR TITLE
Add twoslash snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,30 @@
   "categories": [
     "Other"
   ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": "javascript",
+        "path": "./snippets.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets.json"
+      },
+      {
+        "language": "jsx-tags",
+        "path": "./snippets.json"
+      }
+    ]
+  },
   "activationEvents": [
     "onLanguage:javascript",
     "onLanguage:javascriptreact",

--- a/snippets.json
+++ b/snippets.json
@@ -1,0 +1,7 @@
+{
+  "twoslash": {
+    "prefix": "twoslash",
+    "body": ["//    ^?"],
+    "description": "twoslash query"
+  }
+}


### PR DESCRIPTION
Added a snippet with the right amount of whitespace for both declared `const`s and `type`s i.e.
```ts
const x = 'hi'
//    ^? const hi: 'hi'
type X = 'hi'
//    ^? type Hi = 'hi'
```

## Considerations:
- Making a shorter `// ^?` work with variables declared using any of: `type`, `const`, `let`, and `var`
- Adding "Snippets" to the `package.json` categories