### PR TITLE
Allow //. incase period gets auto inserted

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ export function activate(context: vscode.ExtensionContext) {
       const text = model.getText(iRange);
       const results: vscode.InlayHint[] = [];
 
-      const m = text.matchAll(/^\s*\/\/\s*\^\?/gm);
+      const m = text.matchAll(/^\s*\/\/\.?\s*\^\?/gm);
       for (const match of m) {
         if (match.index === undefined) {
           return;


### PR DESCRIPTION
Some operating systems will auto insert a period when you double tap the space bar. This often leads me to having a comment that looks like this when I am quickly trying to check a type
```
//.        ^?
```

This will not work. The mistake is easy to make and is subtle enough were a lot of people won't notice it. 


[22 seconds into this video](https://youtu.be/u0adKDu--cA?t=22) you can see Matt Pocock struggle with it and GPT told me he invented typescript. 