### PR TITLE
add support for orta.vscode-twoslash-queries.maxLength

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
     "@vscode/test-electron": "^2.1.2"
   },
   "contributes": {
+    "configuration": {
+      "title": "Twoslash Query Comments",
+      "properties": {
+        "orta.vscode-twoslash-queries.maxLength": {
+          "type": "number",
+          "default": 120,
+          "description": "Optionally set a maximum length for the hints to display."
+        }
+      }
+    },
     "commands": [{
       "command": "orta.vscode-twoslash-queries.insert-twoslash-query",
       "title": "TwoSlash Query: Insert Below"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -38,7 +38,10 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
   
   // Cut off hint if too long
   // If microsoft/vscode#174159 lands, can change to check that
-  const availableSpace = 120 - lineLength;
+  const availableSpace =
+    vscode.workspace
+      .getConfiguration("orta.vscode-twoslash-queries")
+      .get<number>("maxLength", 120) - lineLength;
   if (text.length > availableSpace) {
     text = text.slice(0, availableSpace - 1) + "...";
   }


### PR DESCRIPTION
Adding this as an attempt to help with https://github.com/orta/vscode-twoslash-queries/issues/38

My understanding is that this should work once https://github.com/microsoft/vscode/issues/205708 is released 🤞 