### PR TITLE
Add command for inline comment (// =>)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "title": "TwoSlash Query: Insert Below"
       },
       {
-        "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
+        "command": "orta.vscode-twoslash-queries.insert-inline-query",
         "title": "Inline TwoSlash Query: Insert EOL"
       }
     ],
@@ -73,7 +73,7 @@
           "when": "editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascript || editorLangId == javascriptreact"
         },
         {
-          "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
+          "command": "orta.vscode-twoslash-queries.insert-inline-query",
           "when": "editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascript || editorLangId == javascriptreact"
         }
       ]
@@ -86,7 +86,7 @@
         "mac": "cmd+k 6"
       },
       {
-        "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
+        "command": "orta.vscode-twoslash-queries.insert-inline-query",
         "when": "editorTextFocus",
         "key": "ctrl+k 7",
         "mac": "cmd+k 7"

--- a/package.json
+++ b/package.json
@@ -56,14 +56,24 @@
         }
       }
     },
-    "commands": [{
-      "command": "orta.vscode-twoslash-queries.insert-twoslash-query",
-      "title": "TwoSlash Query: Insert Below"
-    }],
+    "commands": [
+      {
+        "command": "orta.vscode-twoslash-queries.insert-twoslash-query",
+        "title": "TwoSlash Query: Insert Below"
+      },
+      {
+        "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
+        "title": "Inline TwoSlash Query: Insert EOL"
+      }
+    ],
     "menus": {
       "commandPalette": [
         {
           "command": "orta.vscode-twoslash-queries.insert-twoslash-query",
+          "when": "editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascript || editorLangId == javascriptreact"
+        },
+        {
+          "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
           "when": "editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascript || editorLangId == javascriptreact"
         }
       ]
@@ -74,6 +84,12 @@
         "when": "editorTextFocus",
         "key": "ctrl+k 6",
         "mac": "cmd+k 6"
+      },
+      {
+        "command": "orta.vscode-twoslash-queries.insert-inline-twoslash-query",
+        "when": "editorTextFocus",
+        "key": "ctrl+k 7",
+        "mac": "cmd+k 7"
       }
     ]
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { getHintsFromQueries } from "./queries";
 export function activate(context: vscode.ExtensionContext) {
   registerInlayHintsProvider(context);
   registerInsertTwoSlashQueryCommand(context);
-  registerInsertInlineTwoSlashQueryCommand(context);
+  registerInsertInlineQueryCommand(context);
 }
 
 export function deactivate() {}
@@ -43,16 +43,17 @@ function registerInsertTwoSlashQueryCommand(context: vscode.ExtensionContext) {
   );
 }
 
-function registerInsertInlineTwoSlashQueryCommand(context: vscode.ExtensionContext) {
+function registerInsertInlineQueryCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerTextEditorCommand(
-      'orta.vscode-twoslash-queries.insert-inline-twoslash-query',
+      'orta.vscode-twoslash-queries.insert-inline-query',
       (textEditor: vscode.TextEditor) => {
         const { document, selection: { end } } = textEditor;
         const eolRange = document.lineAt(end.line).range.end;
         const comment = ' // =>';
 
         textEditor.edit(editBuilder => editBuilder.insert(eolRange, comment));
-      })
+      }
+    )
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { getHintsFromQueries } from "./queries";
 export function activate(context: vscode.ExtensionContext) {
   registerInlayHintsProvider(context);
   registerInsertTwoSlashQueryCommand(context);
+  registerInsertInlineTwoSlashQueryCommand(context);
 }
 
 export function deactivate() {}
@@ -38,6 +39,20 @@ function registerInsertTwoSlashQueryCommand(context: vscode.ExtensionContext) {
           const eolChar = document.eol === vscode.EndOfLine.LF ? '\n' : '\r\n';
           editBuilder.insert(eolRange, eolChar + comment);
         });
+      })
+  );
+}
+
+function registerInsertInlineTwoSlashQueryCommand(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      'orta.vscode-twoslash-queries.insert-inline-twoslash-query',
+      (textEditor: vscode.TextEditor) => {
+        const { document, selection: { end } } = textEditor;
+        const eolRange = document.lineAt(end.line).range.end;
+        const comment = ' // =>';
+
+        textEditor.edit(editBuilder => editBuilder.insert(eolRange, comment));
       })
   );
 }


### PR DESCRIPTION
Love this extension ❤️

Recently discovered that there's an inline version of twoslash as well, this PR adds a keyboard shortcut for the same.

https://github.com/user-attachments/assets/e8b6ea9b-4c7d-4d97-9a98-015f698f7a75

