### PR TITLE
Disable inlay hints when there are characters following ^?

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "orta.vscode-twoslash-queries.enableStrictEnd": {
           "type": "boolean",
           "default": false,
-          "description": "If enabled, type hints are shown only for queries that strictly end with '// ^?'."
+          "description": "If enabled, type hints are shown only for queries that strictly end with '^?'."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
           "type": "number",
           "default": 120,
           "description": "Optionally set a maximum length for the hints to display."
+        },
+        "orta.vscode-twoslash-queries.enableStrictEnd": {
+          "type": "boolean",
+          "default": false,
+          "description": "If enabled, type hints are shown only for queries that strictly end with '// ^?'."
         }
       }
     },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -14,10 +14,15 @@ type RegExpGroups<T extends string> = (
   }[]
 );
 
+const strictEndEnabled = vscode.workspace
+  .getConfiguration("orta.vscode-twoslash-queries")
+  .get<boolean>("enableStrictEnd", false);
 
-const twoslashQueryRegex = /^\s*\/\/\.?\s*\^\?/gm; // symbol: ^?
+const twoslashQueryRegex = strictEndEnabled ? /^\s*\/\/\.?\s*\^\?$/gm: /^\s*\/\/\.?\s*\^\?/gm; // symbol: ^?
 // https://regex101.com/r/6Jb8h2/1
-const inlineQueryRegex = /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
+const inlineQueryRegex = strictEndEnabled
+  ? /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)$/gm
+  : /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
 type InlineQueryMatches = RegExpGroups<"start" | "end">;
 
 type Query = {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -18,11 +18,9 @@ const strictEndEnabled = vscode.workspace
   .getConfiguration("orta.vscode-twoslash-queries")
   .get<boolean>("enableStrictEnd", false);
 
-const twoslashQueryRegex = strictEndEnabled ? /^\s*\/\/\.?\s*\^\?$/gm: /^\s*\/\/\.?\s*\^\?/gm; // symbol: ^?
+const twoslashQueryRegex = new RegExp(/^\s*\/\/\.?\s*\^\?/.source + (strictEndEnabled ? "$" : ""), "gm"); // symbol: ^?
 // https://regex101.com/r/6Jb8h2/1
-const inlineQueryRegex = strictEndEnabled
-  ? /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)$/gm
-  : /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm; // symbol: =>
+const inlineQueryRegex = new RegExp(/^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/.source + (strictEndEnabled ? "$" : ""), "gm"); // symbol: =>
 type InlineQueryMatches = RegExpGroups<"start" | "end">;
 
 type Query = {


### PR DESCRIPTION
The ESLint plugin [eslint-plugin-expect-type](https://www.npmjs.com/package/eslint-plugin-expect-type) enables type testing using the TwoSlash syntax, as illustrated below:
<img width="744" alt="image" src="https://github.com/user-attachments/assets/b5db2051-e3a4-4fd2-b1ce-f6a6095b6198">

However, the inlay hints remain active even when there are characters following ^?, which btw is not the case in the TypeScript Playground.

IMO, this makes it harder to read the tests, as shown below.
<img width="976" alt="image" src="https://github.com/user-attachments/assets/fe2bddee-198b-493f-ae68-ae5f55f6cc4b">

This PR adds a setting to disable this behaviour.