### PR TITLE
Enable vue language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
-    "onLanguage:jsx-tags"
+    "onLanguage:jsx-tags",
+    "onLanguage:vue"
   ],
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ function registerInlayHintsProvider(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.languages.registerInlayHintsProvider(
-      [{ language: "javascript" }, { language: "typescript" }, { language: "typescriptreact" }, { language: "javascriptreact" }],
+      [{ language: "javascript" }, { language: "typescript" }, { language: "typescriptreact" }, { language: "javascriptreact" }, {language: "vue"}],
       provider
     )
   );


### PR DESCRIPTION
As of [volar.js v2.0.0](https://github.com/volarjs/volar.js/releases/tag/v2.0.0), volar (and the vue language server by extension) uses TS plugins instead of a separate typescript language servers. This means that the limitations referenced in https://github.com/orta/vscode-twoslash-queries/issues/3#issuecomment-1196859199_ no longer apply

This PR adds the *vue* language to the activation events and to the list of inlay provider selectors