### PR TITLE
Allow `CMD+6` shortcut to position queries based on previous line's first available hint

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ function registerInsertTwoSlashQueryCommand(context: vscode.ExtensionContext) {
             eolRange = prevLine.range.end;
           }
         }
-        const comment = '//'.padEnd(padding, ' ').concat('^?');
+        const comment = '//'.padStart(currLine.firstNonWhitespaceCharacterIndex + 2).padEnd(padding, ' ').concat('^?');
 
         textEditor.edit(editBuilder => {
           const eolChar = document.eol === vscode.EndOfLine.LF ? '\n' : '\r\n';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -74,3 +74,16 @@ export async function getLeftMostHintOfLine({ model, position, lineLength }: Lin
     return hint;
   }
 }
+
+/** Gets the position of the first `QuickInfo` response in a given line, if available. */
+export async function getPositionOfLeftMostHintOfLine({ model, position, lineLength }: LineInfo) {
+  for (const i of range(lineLength)) {
+    const hint = await quickInfoRequest(model, position.translate(0, i));
+  
+    if (!hint?.body) {
+      continue;
+    }
+
+    return i;
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -74,16 +74,3 @@ export async function getLeftMostHintOfLine({ model, position, lineLength }: Lin
     return hint;
   }
 }
-
-/** Gets the position of the first `QuickInfo` response in a given line, if available. */
-export async function getPositionOfLeftMostHintOfLine({ model, position, lineLength }: LineInfo) {
-  for (const i of range(lineLength)) {
-    const hint = await quickInfoRequest(model, position.translate(0, i));
-  
-    if (!hint?.body) {
-      continue;
-    }
-
-    return i;
-  }
-}


### PR DESCRIPTION
While the `CMD+6` shortcut is useful, it would have been even more useful if I could use the shortcut on an empty line and let the extension figure out the positioning of the two slash query based on the previous line.

This PR implements that functionality. When the command is triggered on an empty line, the extension identifies the leftmost symbol of the previous line with available hint and places the query accordingly.

https://github.com/user-attachments/assets/3e5b8b1a-8506-4e70-b8ad-6a5db54da329

<hr />
<br />

Also, indentations are **not** preserved currently, so something like "format on save" might disturb the positioning of comments, as shown below:

https://github.com/user-attachments/assets/eef88c7d-2894-4f82-bd46-819cc466fbbf

<br />

This PR addresses this issue by preserving indentations, as shown below:

https://github.com/user-attachments/assets/8cd90f88-2a0f-4e72-857f-7b7269ad989f