### PR TITLE
Remove extra spaces from inlay hint

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,9 +31,7 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
   
   // Make a one-liner
   let text = hint.body.displayString
-    .replace(/\\n/g, " ")
-    .replace(/\/n/g, " ")
-    .replace(/  /g, " ")
+    .replace(/\n\s*/g, " ")
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
   
   // Cut off hint if too long

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,8 +31,7 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
   
   // Make a one-liner
   let text = hint.body.displayString
-    .replace(/\n\s*/g, " ")
-    .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
+    .replace(/\n\s*/g, " ");
   
   // Cut off hint if too long
   // If microsoft/vscode#174159 lands, can change to check that

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,7 +31,7 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
   
   // Make a one-liner
   let text = hint.body.displayString
-    .replace(/\n\s*/g, " ");
+    .replace(/\r?\n\s*/g, " ");
   
   // Cut off hint if too long
   // If microsoft/vscode#174159 lands, can change to check that


### PR DESCRIPTION
This PR fixes all the issues mentioned in https://github.com/orta/vscode-twoslash-queries/issues/45.

Currently, the regex for converting the display string to one line doesn't seem correct.

1. The regex in the first `replace`, `/\\n/g`, doesn't match the new line character instead it matches a literal backslash `\` followed by `n`.

   <img width="395" alt="image" src="https://github.com/user-attachments/assets/1f5d455a-6ab4-4498-9d0b-d8a7d927e78c">

2. Similarly, the regex in the second `replace` matches a literal slash `/` followed by `n`.

    <img width="399" alt="image" src="https://github.com/user-attachments/assets/fd131b6e-cd4d-4541-98a5-dc1203b02890">

3. The third regex just replaces two consecutive spaces with a single space, which leaves behind the extra spaces & it also replaces spaces within quoted text.

    <img width="744" alt="image" src="https://github.com/user-attachments/assets/a3921338-f932-4fd8-84a8-26846227fe8b">
    <img width="801" alt="image" src="https://github.com/user-attachments/assets/8093f8f9-eec8-4f1a-b545-135db1a790ac">
    

4. The fourth regex is what currently replaces the new line character.

<br />

This PR, replaces all the regexes with just this `replace(/\r?\n\s*/g, " ")`, which seems to handle all the cases. This is [the same regex](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/playground/src/twoslashInlays.ts#L35) that the TS playground uses.

<img width="640" alt="image" src="https://github.com/user-attachments/assets/4711e10f-ca37-49d8-b54d-653b197a0a19">
