### PR TITLE
Fix #45

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,9 +31,7 @@ export function createInlayHint({ hint, position, lineLength = 0 }: InlayHintInf
   
   // Make a one-liner
   let text = hint.body.displayString
-    .replace(/\\n/g, " ")
-    .replace(/\/n/g, " ")
-    .replace(/  /g, " ")
+    .replace(/\r?\n\s*/g, " ")
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
   
   // Cut off hint if too long


### PR DESCRIPTION
Fixes #45 

One issue remaining:
```ts
type foo = {
  prop: `a
b`;
}
type __ = foo;
//   ^?
// the newline between a and b gets replaced with a space
```
however this is a rare edge case, and the typescript playground has the same issue, so it's probably fine

fixing that would require parsing the output to find string boundaries

