### PR TITLE
Fix inline query not rendering on the last line

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -79,7 +79,7 @@ async function checkInlineQuery({ text, offset, model, cancel }: Query): InlayHi
     const { start, end: querySymbol } = match.groups;
     const startIndex = line.indexOf(start);
     const startPos = model.positionAt(startIndex + offset + match.index);
-    const endIndex = line.lastIndexOf(querySymbol) + 2;
+    const endIndex = line.lastIndexOf(querySymbol) + 1;
     const endPos = model.positionAt(endIndex + offset + match.index);
 
     const hint = await getLeftMostHintOfLine({ model, position: startPos, lineLength: endIndex - startIndex - 2 });


### PR DESCRIPTION
Currently the inline twoslash query (`//=>`) doesn't render when it's placed on the very last line.
<img width="1002" height="382" alt="image" src="https://github.com/user-attachments/assets/8324ad92-86f7-4ac4-b7b7-7c5d05cfa528" />

This happens because the position for the inlay hint is off by `1`. It happens to work when the query is on a non-last line because those lines include an extra `\n` at the end.

This PR fixes this issue.
<img width="998" height="384" alt="image" src="https://github.com/user-attachments/assets/ccaa9fce-f95e-4546-b3e5-71e8a4307cef" />
